### PR TITLE
Add Jest tests for HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "college_football_scoreboard_2023",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('index.html structure', () => {
+  test('document has head and body nested under html', () => {
+    const htmlPath = path.join(__dirname, '..', 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const dom = new JSDOM(html);
+    const { document } = dom.window;
+    expect(document.head).not.toBeNull();
+    expect(document.body).not.toBeNull();
+    expect(document.head.parentElement).toBe(document.documentElement);
+    expect(document.body.parentElement).toBe(document.documentElement);
+  });
+});
+
+


### PR DESCRIPTION
## Summary
- add node project files and ignore node_modules
- add Jest-based test for HTML structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684046ef6e408322a4d043e16423f998